### PR TITLE
Handling of items leaving the scope

### DIFF
--- a/lib/sortifiable.rb
+++ b/lib/sortifiable.rb
@@ -386,7 +386,7 @@ module Sortifiable
         if acts_as_list_options[:scope].is_a?(String)
           instance_eval("\"#{acts_as_list_options[:scope]}\"")
         else
-          Array.wrap(acts_as_list_options[:scope]).inject({}){ |m,k| m[k] = send(k); m }
+          Array.wrap(acts_as_list_options[:scope]).each_with_object({}) { |k, m| m[k] = send(k) }
         end
       end
 

--- a/test/sortifiable_test.rb
+++ b/test/sortifiable_test.rb
@@ -102,8 +102,8 @@ class ListTest < Test::Unit::TestCase
   def setup
     setup_db
     [5, 6].each do |parent_id|
-      (1..4).each do |counter|
-        ListMixin.create! :pos => counter, :parent_id => parent_id
+      (1..4).each do |i|
+        ListMixin.create! :pos => i, :parent_id => parent_id
       end
     end
   end
@@ -328,12 +328,12 @@ class ListTest < Test::Unit::TestCase
 
   def test_higher_items
     assert_equal [1, 2], ListMixin.find(3).higher_items.map(&:id)
-    assert_equal [], ListMixin.find(1).higher_items.map(&:id)
+    assert_equal     [], ListMixin.find(1).higher_items.map(&:id)
   end
 
   def test_lower_items
     assert_equal [3, 4], ListMixin.find(2).lower_items.map(&:id)
-    assert_equal [], ListMixin.find(4).lower_items.map(&:id)
+    assert_equal     [], ListMixin.find(4).lower_items.map(&:id)
   end
 
 end
@@ -533,13 +533,13 @@ class ListSubTest < Test::Unit::TestCase
   def test_higher_items
     ListMixin.find(2).remove_from_list
     assert_equal [1], ListMixin.find(3).higher_items.map(&:id)
-    assert_equal [], ListMixin.find(1).higher_items.map(&:id)
+    assert_equal  [], ListMixin.find(1).higher_items.map(&:id)
   end
 
   def test_lower_items
     ListMixin.find(3).remove_from_list
     assert_equal [4], ListMixin.find(2).lower_items.map(&:id)
-    assert_equal [], ListMixin.find(4).lower_items.map(&:id)
+    assert_equal  [], ListMixin.find(4).lower_items.map(&:id)
   end
 
   def test_list_class
@@ -554,9 +554,9 @@ class ArrayScopeListTest < Test::Unit::TestCase
     setup_db
     ['ParentClass', 'bananas'].each do |parent_type|
       [5, 6].each do |parent_id|
-        (1..4).each do |counter|
+        (1..4).each do |i|
           ArrayScopeListMixin.create!(
-            :pos => counter,
+            :pos => i,
             :parent_id => parent_id,
             :parent_type => parent_type
           )
@@ -620,8 +620,8 @@ class ArrayScopeListTest < Test::Unit::TestCase
 
   def test_injection
     item = ArrayScopeListMixin.new(conditions)
-    assert_equal(conditions, item.send(:scope_condition))
-    assert_equal("pos", item.send(:position_column))
+    assert_equal conditions, item.send(:scope_condition)
+    assert_equal "pos", item.send(:position_column)
   end
 
   def test_insert
@@ -752,7 +752,7 @@ class ArrayScopeListTest < Test::Unit::TestCase
   end
 
   def test_move_to_new_list_by_updating_scope_part_2_should_append
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.where(conditions).map(&:id)
+    assert_equal [1,  2,  3,  4], ArrayScopeListMixin.where(conditions).map(&:id)
     assert_equal [9, 10, 11, 12], ArrayScopeListMixin.where(conditions(:parent_type => 'bananas')).map(&:id)
 
     ArrayScopeListMixin.find(2).update_attributes! :parent_type => 'bananas'
@@ -767,7 +767,7 @@ class ArrayScopeListTest < Test::Unit::TestCase
   end
 
   def test_move_to_new_list_by_updating_complete_scope_should_append
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.where(conditions).map(&:id)
+    assert_equal [ 1,  2,  3,  4], ArrayScopeListMixin.where(conditions).map(&:id)
     assert_equal [13, 14, 15, 16], ArrayScopeListMixin.where(:parent_id => 6, :parent_type => 'bananas').map(&:id)
 
     ArrayScopeListMixin.find(2).update_attributes! :parent_id => 6, :parent_type => 'bananas'
@@ -783,7 +783,9 @@ class ArrayScopeListTest < Test::Unit::TestCase
 
   def test_remove_from_list_should_then_fail_in_list?
     assert_equal true, ArrayScopeListMixin.find(1).in_list?
+
     ArrayScopeListMixin.find(1).remove_from_list
+
     assert_equal false, ArrayScopeListMixin.find(1).in_list?
   end
 
@@ -815,12 +817,12 @@ class ArrayScopeListTest < Test::Unit::TestCase
 
   def test_higher_items
     assert_equal [1, 2], ArrayScopeListMixin.find(3).higher_items.map(&:id)
-    assert_equal [], ArrayScopeListMixin.find(1).higher_items.map(&:id)
+    assert_equal     [], ArrayScopeListMixin.find(1).higher_items.map(&:id)
   end
 
   def test_lower_items
     assert_equal [3, 4], ArrayScopeListMixin.find(2).lower_items.map(&:id)
-    assert_equal [], ArrayScopeListMixin.find(4).lower_items.map(&:id)
+    assert_equal     [], ArrayScopeListMixin.find(4).lower_items.map(&:id)
   end
 
 end
@@ -829,16 +831,16 @@ class AssociationScopeListTest < Test::Unit::TestCase
 
   def setup
     setup_db
-    (1..4).each do |counter|
+    (1..4).each do |i|
       AssociationScopeListMixin.create!(
-        :pos => counter,
+        :pos => i,
         :parent_id => 5
       )
     end
 
-    (1..4).each do |counter|
+    (1..4).each do |i|
       PolymorphicAssociationScopeListMixin.create!(
-        :pos => counter,
+        :pos => i,
         :parent_id => 5,
         :parent_type => 'ParentClass'
       )

--- a/test/sortifiable_test.rb
+++ b/test/sortifiable_test.rb
@@ -108,41 +108,41 @@ class ListTest < Test::Unit::TestCase
   end
 
   def test_reordering
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 3, 2, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [2, 3, 4, 1], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 3, 4, 2], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [4, 1, 3, 2], ListMixin.where(:parent_id => 5).map(&:id)
   end
 
   def test_bounds_checking
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:pos)
 
     ListMixin.find(1).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:pos)
 
     ListMixin.find(4).move_lower
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:pos)
   end
 
   def test_move_to_bottom_with_next_to_last_item
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
     ListMixin.find(3).move_to_bottom
-    assert_equal [1, 2, 4, 3], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 4, 3], ListMixin.where(:parent_id => 5).map(&:id)
   end
 
   def test_next_prev
@@ -216,11 +216,11 @@ class ListTest < Test::Unit::TestCase
   end
 
   def test_delete_middle
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).destroy
 
-    assert_equal [1, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     assert_equal 1, ListMixin.find(1).pos
     assert_equal 2, ListMixin.find(3).pos
@@ -228,7 +228,7 @@ class ListTest < Test::Unit::TestCase
 
     ListMixin.find(1).destroy
 
-    assert_equal [3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     assert_equal 1, ListMixin.find(3).pos
     assert_equal 2, ListMixin.find(4).pos
@@ -244,7 +244,7 @@ class ListTest < Test::Unit::TestCase
   def test_nil_scope
     new1, new2, new3 = ListMixin.create, ListMixin.create, ListMixin.create
     new2.move_higher
-    assert_equal [new2, new1, new3], ListMixin.where('parent_id IS NULL')
+    assert_equal [new2, new1, new3], ListMixin.where(:parent_id => nil)
   end
 
   def test_remove_from_list_should_then_fail_in_list?
@@ -254,11 +254,11 @@ class ListTest < Test::Unit::TestCase
   end
 
   def test_remove_from_list_should_set_position_to_nil
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).remove_from_list
 
-    assert_equal [2, 1, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [2, 1, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     assert_equal 1,   ListMixin.find(1).pos
     assert_equal nil, ListMixin.find(2).pos
@@ -267,12 +267,12 @@ class ListTest < Test::Unit::TestCase
   end
 
   def test_remove_before_destroy_does_not_shift_lower_items_twice
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     ListMixin.find(2).remove_from_list
     ListMixin.find(2).destroy
 
-    assert_equal [1, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     assert_equal 1, ListMixin.find(1).pos
     assert_equal 2, ListMixin.find(3).pos
@@ -280,7 +280,7 @@ class ListTest < Test::Unit::TestCase
   end
 
   def test_before_destroy_callbacks_do_not_update_position_to_nil_before_deleting_the_record
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     # We need to trigger all the before_destroy callbacks without actually
     # destroying the record so we can see the affect the callbacks have on
@@ -292,7 +292,7 @@ class ListTest < Test::Unit::TestCase
       list.send(:callback, :before_destroy)
     end
 
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 
     assert_equal 1, ListMixin.find(1).pos
     assert_equal 2, ListMixin.find(2).pos
@@ -334,41 +334,41 @@ class ListSubTest < Test::Unit::TestCase
   end
 
   def test_reordering
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 3, 2, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [2, 3, 4, 1], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 3, 4, 2], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [4, 1, 3, 2], ListMixin.where(:parent_id => 5000).map(&:id)
   end
 
   def test_bounds_checking
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:pos)
 
     ListMixin.find(1).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:pos)
 
     ListMixin.find(4).move_lower
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:pos)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:pos)
   end
 
   def test_move_to_bottom_with_next_to_last_item
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
     ListMixin.find(3).move_to_bottom
-    assert_equal [1, 2, 4, 3], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 4, 3], ListMixin.where(:parent_id => 5000).map(&:id)
   end
 
   def test_next_prev
@@ -379,22 +379,22 @@ class ListSubTest < Test::Unit::TestCase
   end
 
   def test_injection
-    item = ListMixin.new("parent_id"=>1)
+    item = ListMixin.new(:parent_id => 1)
     assert_equal({ :parent_id => 1 }, item.send(:scope_condition))
     assert_equal("pos", item.send(:position_column))
   end
 
   def test_insert_at
-    new = ListMixin.create("parent_id" => 20)
+    new = ListMixin.create(:parent_id => 20)
     assert_equal 1, new.pos
 
-    new = ListMixinSub1.create("parent_id" => 20)
+    new = ListMixinSub1.create(:parent_id => 20)
     assert_equal 2, new.pos
 
-    new = ListMixinSub2.create("parent_id" => 20)
+    new = ListMixinSub2.create(:parent_id => 20)
     assert_equal 3, new.pos
 
-    new4 = ListMixin.create("parent_id" => 20)
+    new4 = ListMixin.create(:parent_id => 20)
     assert_equal 4, new4.pos
 
     new4.insert_at(3)
@@ -409,7 +409,7 @@ class ListSubTest < Test::Unit::TestCase
     new4.reload
     assert_equal 4, new4.pos
 
-    new5 = ListMixinSub1.create("parent_id" => 20)
+    new5 = ListMixinSub1.create(:parent_id => 20)
     assert_equal 5, new5.pos
 
     new5.insert_at(1)
@@ -420,11 +420,11 @@ class ListSubTest < Test::Unit::TestCase
   end
 
   def test_delete_middle
-    assert_equal [1, 2, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     ListMixin.find(2).destroy
 
-    assert_equal [1, 3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [1, 3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     assert_equal 1, ListMixin.find(1).pos
     assert_equal 2, ListMixin.find(3).pos
@@ -432,7 +432,7 @@ class ListSubTest < Test::Unit::TestCase
 
     ListMixin.find(1).destroy
 
-    assert_equal [3, 4], ListMixin.where('parent_id = 5000').map(&:id)
+    assert_equal [3, 4], ListMixin.where(:parent_id => 5000).map(&:id)
 
     assert_equal 1, ListMixin.find(3).pos
     assert_equal 2, ListMixin.find(4).pos


### PR DESCRIPTION
Hi Andrew,

Have a look at my commits please.
I think I got most of the cases covered.
What I didn't test is what happens when the position column is updated alongside the scope, but I'd say that would be bad practice anyways... mostly the position column is only updated by "move higher" or "move lover" buttons and separately from any other changes to the model. It might still behave as expected when both are updated, though...
Feel free to leave out the commits where I make changes to formatting and syntax, they are mostly due to me being too obsessive about that... :)

Manuel
