### PR TITLE
lock_list!.index(id) fails (type incompatibility)

### DIFF
--- a/lib/sortifiable.rb
+++ b/lib/sortifiable.rb
@@ -438,7 +438,7 @@ module Sortifiable
       end
 
       def lock_list! #:nodoc:
-        connection.select_values(list_scope.select(list_class.primary_key).lock(true).to_sql)
+        connection.select_values(list_scope.select(list_class.primary_key).lock(true).to_sql).map(&:to_i)
       end
 
       def lower_scope(position) #:nodoc:


### PR DESCRIPTION
Convert lock_list result array values to ints. Strings are returned by default for postgres & mysql. We might also choose to change every index(id) call to index(id.to_s) to ensure non-integer primary keys still work as well, but I figured it will usually be an int for AR models. (changed using Github)
