### PR TITLE
Don't scope when updating node position

### DIFF
--- a/lib/sortifiable.rb
+++ b/lib/sortifiable.rb
@@ -476,7 +476,7 @@ module Sortifiable
       end
 
       def update_position(new_position) #:nodoc:
-        base_scope.where({ list_class.primary_key => id }).update_all({ position_column => new_position })
+        list_class.unscoped.where({ list_class.primary_key => id }).update_all({ position_column => new_position }) #.tap{|result| raise 'update_position failed' if result.zero? }
         set_position new_position
       end
   end

--- a/sortifiable.gemspec
+++ b/sortifiable.gemspec
@@ -35,7 +35,7 @@ EOF
   s.test_files    = ["test/sortifiable_test.rb"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "activesupport", ">= 3.0"
+  s.add_dependency "activesupport", ">= 3.0", "<= 4.1"
   s.add_dependency "activerecord", ">= 3.0"
   s.add_development_dependency "appraisal", "~> 0.5"
   s.add_development_dependency "mysql", ">= 2.8.1"

--- a/test/sortifiable_test.rb
+++ b/test/sortifiable_test.rb
@@ -245,6 +245,24 @@ class ListTest < ActiveSupport::TestCase
     assert_equal 5, ListMixin.find(2).pos
   end
 
+  def test_move_to_new_list_by_updating_parent_should_keep_position_integrity
+    assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:pos)
+
+    ListMixin.where(:parent_id => 5).each do |mixin|
+      mixin.parent_id = 6
+      assert mixin.save
+    end
+
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8], ListMixin.where(:parent_id => 6).map(&:pos)
+
+    ListMixin.where(:parent_id => 6).each do |mixin|
+      mixin.parent_id = 5
+      assert mixin.save
+    end
+
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8], ListMixin.where(:parent_id => 5).map(&:pos)
+  end
+
   def test_before_destroy_callbacks_do_not_update_position_to_nil_before_deleting_the_record
     assert_equal [1, 2, 3, 4], ListMixin.where(:parent_id => 5).map(&:id)
 


### PR DESCRIPTION
Hi,

We're using acts_as_list in combination with the ancestry gem and we stumbled upon a bug when updating the parent of a node. When the code changed the parent, the ancestry of the node was changed in memory, but not in the database. However, before save the update_position method would evaluate the scope condition and yield an sql query that contained the new ancestry scope, which wasn't saved to the database yet. The position was therefore not updated, resulting in nodes that all have position 1.

This commit adds a test that demonstrates the problem and I fixed it by unscoping the update. I think the base scope is not needed in update_position, since we're already passing the ID of the object. It might be that I'm overlooking something though :)
